### PR TITLE
#20 elasticsearch 6 document type breaking change

### DIFF
--- a/src/App.Metrics.Formatters.Elasticsearch/Internal/BulkPayload.cs
+++ b/src/App.Metrics.Formatters.Elasticsearch/Internal/BulkPayload.cs
@@ -49,7 +49,7 @@ namespace App.Metrics.Formatters.Elasticsearch.Internal
             {
                 _serializer.Serialize(
                     textWriter,
-                    new BulkDocumentMetaData(_indexName, document.MeasurementType, documentId));
+                    new BulkDocumentMetaData($"{_indexName}.{document.MeasurementType}", document.MeasurementType, documentId));
 
                 textWriter.Write('\n');
                 _serializer.Serialize(textWriter, document);

--- a/test/App.Metrics.Reporting.Elasticsearch.Facts/BulkPayloadTest.cs
+++ b/test/App.Metrics.Reporting.Elasticsearch.Facts/BulkPayloadTest.cs
@@ -36,7 +36,7 @@ namespace App.Metrics.Reporting.Elasticsearch.Facts
             bulkPayload.Write(textWriter, documentId);
 
             // Assert
-            textWriter.ToString().Should().Be("{\"index\":{\"_index\":\"index\",\"_type\":\"counter\",\"_id\":\"" + documentId.ToString("D") + "\"}}\n{\"name\":\"measurement\",\"fields\":{\"key\":\"value\"},\"tags\":null,\"@timestamp\":\"2017-01-01T01:01:01Z\"}\n");
+            textWriter.ToString().Should().Be("{\"index\":{\"_index\":\"index.counter\",\"_type\":\"counter\",\"_id\":\"" + documentId.ToString("D") + "\"}}\n{\"name\":\"measurement\",\"fields\":{\"key\":\"value\"},\"tags\":null,\"@timestamp\":\"2017-01-01T01:01:01Z\"}\n");
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace App.Metrics.Reporting.Elasticsearch.Facts
             bulkPayload.Write(textWriter, documentId);
 
             // Assert
-            textWriter.ToString().Should().Be("{\"index\":{\"_index\":\"index\",\"_type\":\"counter\",\"_id\":\"" + documentId.ToString("D") + "\"}}\n{\"name\":\"measurement\",\"fields\":{\"field1key\":\"field1value\",\"field2key\":2,\"field3key\":false},\"tags\":null,\"@timestamp\":\"2017-01-01T01:01:01Z\"}\n");
+            textWriter.ToString().Should().Be("{\"index\":{\"_index\":\"index.counter\",\"_type\":\"counter\",\"_id\":\"" + documentId.ToString("D") + "\"}}\n{\"name\":\"measurement\",\"fields\":{\"field1key\":\"field1value\",\"field2key\":2,\"field3key\":false},\"tags\":null,\"@timestamp\":\"2017-01-01T01:01:01Z\"}\n");
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace App.Metrics.Reporting.Elasticsearch.Facts
             bulkPayload.Write(textWriter, documentId);
 
             // Assert
-            textWriter.ToString().Should().Be("{\"index\":{\"_index\":\"index\",\"_type\":\"counter\",\"_id\":\"" + documentId.ToString("D") + "\"}}\n{\"name\":\"measurement\",\"fields\":{\"key\":\"value\"},\"tags\":{\"tagkey\":\"tagvalue\"},\"@timestamp\":\"2017-01-01T01:01:01Z\"}\n");
+            textWriter.ToString().Should().Be("{\"index\":{\"_index\":\"index.counter\",\"_type\":\"counter\",\"_id\":\"" + documentId.ToString("D") + "\"}}\n{\"name\":\"measurement\",\"fields\":{\"key\":\"value\"},\"tags\":{\"tagkey\":\"tagvalue\"},\"@timestamp\":\"2017-01-01T01:01:01Z\"}\n");
         }
 
         [Fact]


### PR DESCRIPTION
### The issue or feature being addressed

a fix for #20 

### Details on the issue fix or feature implementation

append document type to elasticsearch index name to don't use same index for different document type which is forbidden in v6 od elastic search.

### Confirm the following

- [X ] I have ensured that I have merged the latest changes from the dev branch
- [ X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [X ] I have included unit tests for the issue/feature
- [X ] I have included the github issue number in my commits 