### PR TITLE
Initial implementation of Health.ElasticReporter.

### DIFF
--- a/AppMetrics.Extensions.Elasticsearch.sln
+++ b/AppMetrics.Extensions.Elasticsearch.sln
@@ -58,6 +58,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App.Metrics.Formatters.Elas
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App.Metrics.Formatting.ElasticSearch", "src\App.Metrics.Formatting.ElasticSearch\App.Metrics.Formatting.ElasticSearch.csproj", "{3A02E3DC-B24A-4260-9F58-F30F3E239411}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Metrics.Health.Reporting.Elastic", "src\App.Metrics.Health.Reporting.Elastic\App.Metrics.Health.Reporting.Elastic.csproj", "{CB246554-6B4D-4255-9C7A-46CAD9008E39}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +82,10 @@ Global
 		{3A02E3DC-B24A-4260-9F58-F30F3E239411}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3A02E3DC-B24A-4260-9F58-F30F3E239411}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3A02E3DC-B24A-4260-9F58-F30F3E239411}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB246554-6B4D-4255-9C7A-46CAD9008E39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB246554-6B4D-4255-9C7A-46CAD9008E39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB246554-6B4D-4255-9C7A-46CAD9008E39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB246554-6B4D-4255-9C7A-46CAD9008E39}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,5 +100,6 @@ Global
 		{6A8C1BAE-B40B-4F12-8C04-8CE911330532} = {31A4DDB1-952E-4EED-96EF-29C669279A86}
 		{79110628-27BA-476B-B4DE-93B09EC815A0} = {2D805782-756E-4C98-B22E-F502BEE95318}
 		{3A02E3DC-B24A-4260-9F58-F30F3E239411} = {2D805782-756E-4C98-B22E-F502BEE95318}
+		{CB246554-6B4D-4255-9C7A-46CAD9008E39} = {2D805782-756E-4C98-B22E-F502BEE95318}
 	EndGlobalSection
 EndGlobal

--- a/src/App.Metrics.Health.Reporting.Elastic/App.Metrics.Health.Reporting.Elastic.csproj
+++ b/src/App.Metrics.Health.Reporting.Elastic/App.Metrics.Health.Reporting.Elastic.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <LangVersion>7.1</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="App.Metrics.Health" Version="3.1.0" />
+      <PackageReference Include="NEST" Version="6.4.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/App.Metrics.Health.Reporting.Elastic/Builder/ElasticHealthAlerterBuilderExtensions.cs
+++ b/src/App.Metrics.Health.Reporting.Elastic/Builder/ElasticHealthAlerterBuilderExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Nest;
+
+namespace App.Metrics.Health.Reporting.Elastic.Builder
+{
+    public static class ElasticHealthAlerterBuilderExtensions
+    {
+        public static IHealthBuilder ToElastic(
+            this IHealthReportingBuilder healthReportingBuilder,
+            Action<ElasticHealthAlertOptions> optionsSetup)
+        {
+            var options = new ElasticHealthAlertOptions();
+
+            optionsSetup(options);
+            
+            if (string.IsNullOrEmpty(options.Uri))
+            {
+                throw new ArgumentNullException(nameof(options.Uri),"Please provide a URI that we need to write health checks to");
+            }
+
+            var elasticClient = new ElasticClient(new Uri(options.Uri));
+            healthReportingBuilder.Using(new ElasticHealthAlerter(options, elasticClient));
+
+            return healthReportingBuilder.Builder;
+        }
+
+        public static IHealthBuilder ToElastic(
+            this IHealthReportingBuilder healthReportingBuilder,
+            ElasticHealthAlertOptions options)
+        {
+            if (string.IsNullOrEmpty(options.Uri))
+            {
+                throw new ArgumentNullException(nameof(options.Uri),"Please provide a URI that we need to write health checks to");
+            }
+
+            var elasticClient = new ElasticClient(new Uri(options.Uri));
+            healthReportingBuilder.Using(new ElasticHealthAlerter(options, elasticClient));
+
+            return healthReportingBuilder.Builder;
+        }
+    }
+}

--- a/src/App.Metrics.Health.Reporting.Elastic/ElasticHealthAlertOptions.cs
+++ b/src/App.Metrics.Health.Reporting.Elastic/ElasticHealthAlertOptions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace App.Metrics.Health.Reporting.Elastic
+{
+    public class ElasticHealthAlertOptions
+    {
+        public bool AlertOnDegradedChecks { get; set; } = true;
+
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        ///     Gets or sets the health status reporting interval.
+        /// </summary>
+        /// <remarks>
+        ///     If not set reporting interval will be set to the <see cref="HealthConstants.Reporting.DefaultReportInterval" />.
+        /// </remarks>
+        /// <value>
+        ///     The <see cref="TimeSpan" /> to wait between reporting health status.
+        /// </value>
+        public TimeSpan ReportInterval { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the number of report runs before re-alerting checks that have re-failed. If set to 0, failed checks will only be reported once until healthy again.
+        /// </summary>
+        /// <remarks>
+        ///     If not set number of runs will be set to the <see cref="HealthConstants.Reporting.DefaultNumberOfRunsBeforeReAlerting" />.
+        /// </remarks>
+        public int RunsBeforeReportExistingFailures { get; set; } = HealthConstants.Reporting.DefaultNumberOfRunsBeforeReAlerting;
+
+        public string ApplicationName { get; set; }
+
+        public string Index { get; set; }
+        
+        public string Uri { get; set; }
+    }
+}

--- a/src/App.Metrics.Health.Reporting.Elastic/ElasticHealthAlerter.cs
+++ b/src/App.Metrics.Health.Reporting.Elastic/ElasticHealthAlerter.cs
@@ -1,0 +1,235 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using App.Metrics.Health.Logging;
+using App.Metrics.Health.Reporting.Elastic.Internal;
+using Nest;
+
+namespace App.Metrics.Health.Reporting.Elastic
+{
+    public class ElasticHealthAlerter : IReportHealthStatus
+    {
+        private static readonly HashSet<string> LastUnhealthyCheckCache = new HashSet<string>();
+        private static readonly HashSet<string> LastDegradedCheckCache = new HashSet<string>();
+        private static readonly ILog Logger = LogProvider.For<ElasticHealthAlerter>();
+        private static int _runs = 0;
+        private readonly IElasticClient _client;
+        private readonly ElasticHealthAlertOptions _options;
+
+        public ElasticHealthAlerter(ElasticHealthAlertOptions options, IElasticClient client)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+
+            ReportInterval = options.ReportInterval > TimeSpan.Zero
+                ? options.ReportInterval
+                : HealthConstants.Reporting.DefaultReportInterval;
+
+            Logger.Trace($"Using Metrics Reporter {this}. Index: {options.Index} ReportInterval: {ReportInterval}");
+        }
+
+        /// <inheritdoc />
+        public TimeSpan ReportInterval { get; set; }
+
+        /// <inheritdoc />
+        public async Task ReportAsync(HealthOptions options, HealthStatus status,
+            CancellationToken cancellationToken = default)
+        {
+            var resetRuns = false;
+            _runs++;
+
+            if (!_options.Enabled || !options.Enabled)
+            {
+                Logger.Trace($"Health Status Reporter `{this}` disabled, not reporting.");
+
+                return;
+            }
+
+            Logger.Trace($"Health Status Reporter `{this}` reporting health status.");
+
+            var healthCheckItems = new List<ElasticHealthCheckDocument>();
+
+            var newUnhealthyChecks = status.Results.Where(r =>
+                r.Check.Status == HealthCheckStatus.Unhealthy && !LastUnhealthyCheckCache.Contains(r.Name)).ToList();
+
+            if (newUnhealthyChecks.Any())
+            {
+                AddHealthChecks(HealthCheckStatus.Unhealthy, newUnhealthyChecks, healthCheckItems);
+            }
+
+            if (_runs > _options.RunsBeforeReportExistingFailures)
+            {
+                resetRuns = true;
+
+                var existingUnHealthyChecks = status.Results
+                    .Where(r => r.Check.Status == HealthCheckStatus.Unhealthy &&
+                                LastUnhealthyCheckCache.Contains(r.Name) &&
+                                newUnhealthyChecks.All(c => c.Name != r.Name))
+                    .ToList();
+
+                if (existingUnHealthyChecks.Any())
+                {
+                    AddHealthChecks(HealthCheckStatus.Unhealthy, existingUnHealthyChecks, healthCheckItems);
+                }
+            }
+
+            if (_options.AlertOnDegradedChecks)
+            {
+                var degradedChecks = status.Results.Where(r =>
+                    r.Check.Status == HealthCheckStatus.Degraded && !LastDegradedCheckCache.Contains(r.Name)).ToList();
+
+                if (degradedChecks.Any())
+                {
+                    AddHealthChecks(HealthCheckStatus.Degraded, degradedChecks, healthCheckItems);
+                }
+
+                if (_runs > _options.RunsBeforeReportExistingFailures)
+                {
+                    resetRuns = true;
+
+                    var existingDegradedChecks = status.Results
+                        .Where(r => r.Check.Status == HealthCheckStatus.Degraded &&
+                                    LastDegradedCheckCache.Contains(r.Name) &&
+                                    degradedChecks.All(c => c.Name != r.Name))
+                        .ToList();
+
+                    if (existingDegradedChecks.Any())
+                    {
+                        AddHealthChecks(HealthCheckStatus.Degraded, existingDegradedChecks, healthCheckItems);
+                    }
+                }
+            }
+
+            if (resetRuns)
+            {
+                _runs = 0;
+            }
+
+            if (healthCheckItems.Any())
+            {
+                try
+                {
+                    var bulkRequest = new BulkRequest(_options.Index) {Operations = new List<IBulkOperation>()};
+
+                    foreach (var item in healthCheckItems)
+                    {
+                        bulkRequest.Operations.Add(new BulkIndexOperation<ElasticHealthCheckDocument>(item));
+                    }
+
+                    var response = await _client.BulkAsync(bulkRequest, cancellationToken);
+
+                    if (response.IsValid)
+                    {
+                        Logger.Trace($"Health Status Reporter `{this}` successfully reported health status.");
+                    }
+                    else
+                    {
+                        Logger.Error(
+                            $"Health Status Reporter `{this}` failed to reported health status with status code: Invalid and reason phrase: `{response.OriginalException}`");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, $"Health Status Reporter `{this}` failed to reported health status");
+                }
+            }
+
+            await AlertStatusChangeChecks(status, cancellationToken);
+        }
+
+        private void AddHealthChecks(
+            HealthCheckStatus checkStatus,
+            IReadOnlyCollection<HealthCheck.Result> checks,
+            List<ElasticHealthCheckDocument> documents)
+        {
+            foreach (var result in checks)
+            {
+                if (result.Check.Status == HealthCheckStatus.Unhealthy)
+                {
+                    LastDegradedCheckCache.Remove(result.Name);
+                    LastUnhealthyCheckCache.Add(result.Name);
+                }
+                else if (result.Check.Status == HealthCheckStatus.Degraded)
+                {
+                    LastUnhealthyCheckCache.Remove(result.Name);
+                    LastDegradedCheckCache.Add(result.Name);
+                }
+
+                var doc = new ElasticHealthCheckDocument(_options.ApplicationName, result.Name)
+                {
+                    CheckStatus = result.Check.Status.ToString(),
+                    Message = result.Check.Message
+                };
+
+                documents.Add(doc);
+            }
+        }
+
+        private async Task AlertStatusChangeChecks(HealthStatus status,
+            CancellationToken cancellationToken)
+        {
+            var healthyChecks = status.Results.Where(r => r.Check.Status == HealthCheckStatus.Healthy).ToList();
+
+            if (!healthyChecks.Any())
+            {
+                return;
+            }
+
+            var recoveredChecks = new List<HealthCheck.Result>();
+
+            foreach (var check in healthyChecks)
+            {
+                if (LastUnhealthyCheckCache.Contains(check.Name))
+                {
+                    recoveredChecks.Add(check);
+                    LastUnhealthyCheckCache.Remove(check.Name);
+                    LastDegradedCheckCache.Remove(check.Name);
+                }
+                else if (LastDegradedCheckCache.Contains(check.Name))
+                {
+                    recoveredChecks.Add(check);
+                    LastDegradedCheckCache.Remove(check.Name);
+                    LastUnhealthyCheckCache.Remove(check.Name);
+                }
+            }
+
+            if (recoveredChecks.Any())
+            {
+                try
+                {
+                    var bulkRequest = new BulkRequest(_options.Index) {Operations = new List<IBulkOperation>()};
+
+                    foreach (var check in recoveredChecks)
+                    {
+                        bulkRequest.Operations.Add(new BulkIndexOperation<ElasticHealthCheckDocument>(
+                            new ElasticHealthCheckDocument(_options.ApplicationName, check.Name)
+                            {
+                                CheckStatus = check.Check.Status.ToString(),
+                                Message = check.Check.Message
+                            }));
+                    }
+
+                    var response = await _client.BulkAsync(bulkRequest, cancellationToken);
+
+                    if (response.IsValid)
+                    {
+                        Logger.Trace($"Health Status Reporter `{this}` successfully reported health status changes.");
+
+                        await AlertStatusChangeChecks(status, cancellationToken);
+                    }
+                    else
+                    {
+                        Logger.Error(
+                            $"Health Status Reporter `{this}` failed to reported health status changes with status code: Invalid and reason phrase: `{response.OriginalException}`");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, $"Health Status Reporter `{this}` failed to reported health status changes.");
+                }
+            }
+        }
+    }
+}

--- a/src/App.Metrics.Health.Reporting.Elastic/Internal/ElasticHealthCheckDocument.cs
+++ b/src/App.Metrics.Health.Reporting.Elastic/Internal/ElasticHealthCheckDocument.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace App.Metrics.Health.Reporting.Elastic.Internal
+{
+    internal class ElasticHealthCheckDocument
+    {
+        private readonly string _healthCheckName;
+        private readonly string _applicationName;
+
+        private string SanitizePattern => "[^a-zA-Z0-9-]+";
+
+        public ElasticHealthCheckDocument(string applicationName, string healthCheckName, string type = null)
+        {
+            _healthCheckName = healthCheckName ?? throw new ArgumentNullException(nameof(healthCheckName));
+            _applicationName = applicationName ?? throw new ArgumentNullException(nameof(applicationName));;
+        }
+
+        public string Id => string.Join("-", ApplicationName, HealthCheckName);
+
+        private string HealthCheckName => Regex.Replace(_healthCheckName, SanitizePattern, "_").ToLowerInvariant();
+
+        private string ApplicationName => Regex.Replace(_applicationName, SanitizePattern, "_").ToLowerInvariant();
+
+        public string CheckStatus { get; set; }
+        
+        public string Message { get; set; }
+    }
+}


### PR DESCRIPTION
### ElasticSearch.Health.Reporter

- [App.Metrics - ISSUE 429](https://github.com/AppMetrics/AppMetrics/issues/429)

### New extension for the health builder

```
   healthBuilder.Report.ToElastic();
```

_(will update and check off items below as I verify the steps. I have just started the PR as a means to create visibility)_
### Confirm the following

- [ ] I have ensured that I have merged the latest changes from the dev branch
- [ ] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
     (this reposter is running on my own app... but I don't think is dotnet framework compatible due to the usage of the NEST module) 
- [ ] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits 